### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Reporting [![Build Status](https://api.travis-ci.com/apache/fineract-cn-reporting.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-reporting) [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-reporting)](https://hub.docker.com/r/apache/fineract-cn-reporting/builds)
+# Apache Fineract CN Reporting [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-reporting)](https://hub.docker.com/r/apache/fineract-cn-reporting/builds)
 
 This project provides simple reporting capabilities.
 [Read more](https://cwiki.apache.org/confluence/display/FINERACT/Fineract+CN+Project+Structure#FineractCNProjectStructure-reporting).


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.